### PR TITLE
Update README.md with latest IJHPCN citation information

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,15 @@ Robert Searles, Stephen Herbein, Travis Johnston, Michela Taufer, Sunita Chandra
 
 DOI: 10.1504/IJHPCN.2017.10007922
 ```
-@INPROCEEDINGS{searles2017portable, 
-author={Searles, Robert and Herbein, Stephen and Johnston, Travis and Taufer, Michela and Chandrasekaran, Sunita}, 
-booktitle={International Journal of High Performance Computing and Networking}, 
-title={Creating a Portable, High-Level Graph Analytics Paradigm For Compute and Data-Intensive Applications}, 
-year={2017}, 
-volume={10},  
-doi={10.1504/IJHPCN.2017.10007922}, 
-month={Jan},}
+@ARTICLE{searles2017portable,
+author={Searles, Robert and Herbein, Stephen and Johnston, Travis and Taufer, Michela and Chandrasekaran, Sunita},
+journal={International Journal of High Performance Computing and Networking},
+title={Creating a Portable, High-Level Graph Analytics Paradigm For Compute and Data-Intensive Applications},
+year={2019},
+volume={13},
+issue={1},
+pages={105-118},
+doi={10.1504/IJHPCN.2019.097054},
+month={Jan},
+}
 ```


### PR DESCRIPTION
Two minor changes:

1. Since IJHPCN is a journal, change the bibtex label from `inproceedings` to `article` and `booktitle` to `journal`
2. Change the metadata (`volume`, `issue`, `pages`, `doi`) to match the new information on the IJHPCN website, which claims that our article was in volume 13, issue 1, and they have issued a new DOI number: https://www.inderscienceonline.com/doi/abs/10.1504/IJHPCN.2019.097054

